### PR TITLE
Implement Go CLI for Node.js monorepo scaffolding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# Agent Instructions
+
+## Project Goals
+This repository should provide a Go-based CLI (`node-creator`) that scaffolds a monorepo-style Node.js backend project with configurable modules and infrastructure.
+
+## Required Features
+- Initialize a Go module and implement the CLI entry point (e.g., using Cobra) under `cmd/node-creator`.
+- CLI command to generate Node.js project templates with selectable modules: routes, controllers, services, repositories, middleware, helpers.
+- Scaffold a shared `packages` (or similar) directory that contains reusable monorepo resources: database clients, libraries, and Redis caching utilities.
+- Support environment-based configuration files for `local`, `dev`, `stg`, and `prod` (`.env` variants keyed by `NODE_ENV`).
+- Generate database configuration using an ORM with choice between MySQL, PostgreSQL, or MongoDB.
+- Provide Redis caching support with customizable namespaced keys (e.g., `namespace:group:key`) and configurable TTL, without per-route cache strategy toggles (to be added later).
+- Offer options to scaffold both `apps/api` and `apps/worker` folders that consume the shared monorepo resources.
+- Include logging setup that writes HTTP access logs to files and separates `log`, `error`, and `warn` outputs with daily file rotation.
+- Provide authentication scaffolding that can be configured to use either JWT or PASETO.
+- Include Prettier and ESLint configuration in generated projects by default.
+- Provide template files for all layers (routes, controllers, services, repositories, middleware, helpers, DB config, caching helpers, logging, auth, env files).
+- Implement option parsing for module selection, database choice, shared resource setup, authentication method, and other configuration toggles.
+- Render templates into a target directory, wiring monorepo structure, DB, caching, logging, and authentication selections accordingly.
+- Include unit tests covering template rendering for key option combinations.
+- Document installation, usage, and configuration in `README.md` (including CLI commands and troubleshooting).
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,97 @@
 # node-creator-cli
+
+`node-creator` is a Go-based CLI that scaffolds a monorepo-style Node.js backend with opinionated defaults for API and worker apps, shared infrastructure packages, and environment-aware configuration.
+
+## Features
+
+- Selectable modules (routes, controllers, services, repositories, middleware, helpers) for the API workspace.
+- Shared `packages/shared` library with database, Redis cache, logging, authentication, and helper utilities.
+- Database scaffolding using TypeORM for MySQL/PostgreSQL or the MongoDB driver.
+- Redis cache utilities with customizable namespace/group/TTL key prefixing.
+- Optional API and worker applications that both consume the shared libraries.
+- Environment presets for `local`, `dev`, `stg`, and `prod`.
+- HTTP access logging to files plus JSON structured logs with daily rotation for `info`, `warn`, and `error`.
+- Authentication templates supporting either JWT or PASETO tokens.
+- Prettier and ESLint configuration included by default.
+
+## Installation
+
+```bash
+go install github.com/example/node-creator-cli/cmd/node-creator@latest
+```
+
+The command installs a `node-creator` binary in your `$GOBIN` (default `$GOPATH/bin`).
+
+## Usage
+
+```bash
+node-creator generate <project-name> [flags]
+```
+
+### Key Flags
+
+| Flag | Description | Default |
+| ---- | ----------- | ------- |
+| `--modules` | Comma-separated list of API modules (`routes,controllers,services,repositories,middleware,helpers`). | all modules |
+| `--database` | ORM target: `mysql`, `postgres`, or `mongodb`. | `mysql` |
+| `--auth` | Authentication provider: `jwt` or `paseto`. | `jwt` |
+| `--api` | Generate the API workspace. | `true` |
+| `--worker` | Generate the worker workspace. | `true` |
+| `--cache-namespace` | Redis namespace prefix. | `app` |
+| `--cache-group` | Redis group segment. | `default` |
+| `--cache-ttl` | Default Redis TTL (seconds). | `300` |
+| `--output` | Destination directory (defaults to `<project-name>`). | *(project name)* |
+
+### Example
+
+```bash
+node-creator generate awesome-app \
+  --modules routes,controllers,services \
+  --database postgres \
+  --auth paseto \
+  --cache-namespace awesome \
+  --cache-group api \
+  --cache-ttl 900
+```
+
+The above command creates the following top-level structure:
+
+```
+awesome-app/
+  apps/
+    api/
+    worker/
+  packages/
+    shared/
+  config/env/
+```
+
+## Generated Workspaces
+
+- **apps/api** – Express-based HTTP service pre-wired with selected modules, shared logging, and Redis helpers.
+- **apps/worker** – BullMQ-based worker ready to share Redis connections and loggers with the API.
+- **packages/shared** – Contains:
+  - `database`: ORM configuration tailored to the selected database.
+  - `cache/redis`: Redis helper with namespace/group/TTL helpers.
+  - `libs/logger` & `libs/httpLogger`: Winston and Morgan-based loggers with daily rotating file output.
+  - `auth`: Wrapper exposing JWT or PASETO utilities depending on CLI choice.
+  - `helpers`: Miscellaneous helper utilities.
+
+## Environment Configuration
+
+Four `.env` files are generated under `config/env` (`.env.local`, `.env.dev`, `.env.stg`, `.env.prod`). Each file includes the Redis namespace/group/TTL selections plus placeholders for database and secret values. Override `ENV_FILE` at runtime to select a different environment preset.
+
+## Testing the CLI
+
+Run the generator tests to verify template rendering for different configuration combinations:
+
+```bash
+go test ./...
+```
+
+## Contributing
+
+1. Fork the repository and create a feature branch.
+2. Add or update templates under `templates/` as needed.
+3. Add unit tests in `internal/generator` to cover new scenarios.
+4. Run `go fmt ./...` and `go test ./...` before submitting a PR.

--- a/cmd/node-creator/main.go
+++ b/cmd/node-creator/main.go
@@ -1,0 +1,7 @@
+package main
+
+import "github.com/example/node-creator-cli/internal/cli"
+
+func main() {
+	cli.Execute()
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,9 @@
+module github.com/example/node-creator-cli
+
+go 1.24.3
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/cobra v1.7.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
+github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/cli/generate.go
+++ b/internal/cli/generate.go
@@ -1,0 +1,59 @@
+package cli
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/example/node-creator-cli/internal/generator"
+)
+
+func newGenerateCmd() *cobra.Command {
+	opts := generator.Options{}
+
+	cmd := &cobra.Command{
+		Use:   "generate [project_name]",
+		Short: "Generate a Node.js monorepo project",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts.ProjectName = args[0]
+
+			if opts.OutputDir == "" {
+				opts.OutputDir = opts.ProjectName
+			}
+
+			opts.Modules = normalizeModules(opts.Modules)
+
+			return generator.New(opts).Generate(cmd.Context())
+		},
+	}
+
+	cmd.Flags().StringSliceVar(&opts.Modules, "modules", []string{"routes", "controllers", "services", "repositories", "middleware", "helpers"}, "Comma-separated list of modules to include")
+	cmd.Flags().StringVar(&opts.Database, "database", "mysql", "Database type to configure (mysql, postgres, mongodb)")
+	cmd.Flags().StringVar(&opts.Auth, "auth", "jwt", "Authentication strategy (jwt or paseto)")
+	cmd.Flags().BoolVar(&opts.IncludeAPI, "api", true, "Generate API application")
+	cmd.Flags().BoolVar(&opts.IncludeWorker, "worker", true, "Generate worker application")
+	cmd.Flags().StringVar(&opts.CacheNamespace, "cache-namespace", "app", "Redis cache namespace prefix")
+	cmd.Flags().StringVar(&opts.CacheGroup, "cache-group", "default", "Redis cache group segment")
+	cmd.Flags().IntVar(&opts.CacheTTL, "cache-ttl", 300, "Redis cache TTL in seconds")
+	cmd.Flags().StringVar(&opts.OutputDir, "output", "", "Target directory for the generated project")
+
+	return cmd
+}
+
+func normalizeModules(mods []string) []string {
+	result := make([]string, 0, len(mods))
+	seen := map[string]struct{}{}
+	for _, m := range mods {
+		m = strings.TrimSpace(strings.ToLower(m))
+		if m == "" {
+			continue
+		}
+		if _, ok := seen[m]; ok {
+			continue
+		}
+		seen[m] = struct{}{}
+		result = append(result, m)
+	}
+	return result
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,0 +1,28 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// NewRootCmd builds the root command for the node-creator CLI.
+func NewRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "node-creator",
+		Short: "Node.js monorepo project scaffolding tool",
+	}
+
+	cmd.AddCommand(newGenerateCmd())
+
+	return cmd
+}
+
+// Execute runs the CLI application.
+func Execute() {
+	if err := NewRootCmd().Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/internal/generator/errors.go
+++ b/internal/generator/errors.go
@@ -1,0 +1,14 @@
+package generator
+
+import "errors"
+
+var (
+	// ErrUnsupportedDatabase indicates the database option is not supported.
+	ErrUnsupportedDatabase = errors.New("unsupported database option")
+	// ErrUnsupportedAuth indicates the auth strategy is not supported.
+	ErrUnsupportedAuth = errors.New("unsupported auth strategy option")
+	// ErrMissingProjectName indicates the project name is required.
+	ErrMissingProjectName = errors.New("project name is required")
+	// ErrNoAppSelected indicates at least one application must be selected.
+	ErrNoAppSelected = errors.New("at least one application (api or worker) must be generated")
+)

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -1,0 +1,173 @@
+package generator
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"text/template"
+
+	"github.com/example/node-creator-cli/templates"
+)
+
+type templateDefinition struct {
+	TemplatePath string
+	TargetPath   string
+	Condition    func(Options) bool
+}
+
+type Generator struct {
+	opts Options
+}
+
+// New creates a generator instance with the provided options.
+func New(opts Options) *Generator {
+	return &Generator{opts: opts}
+}
+
+// Generate renders the Node.js project scaffolding to disk.
+func (g *Generator) Generate(ctx context.Context) error { // ctx currently unused but reserved for future IO cancellation.
+	if err := g.opts.Validate(); err != nil {
+		return err
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+
+	targetDir, err := filepath.Abs(g.opts.OutputDir)
+	if err != nil {
+		return fmt.Errorf("resolve output directory: %w", err)
+	}
+
+	if err := os.MkdirAll(targetDir, 0o755); err != nil {
+		return fmt.Errorf("create output directory: %w", err)
+	}
+
+	data := buildTemplateData(g.opts)
+
+	for _, def := range templateCatalog {
+		if def.Condition != nil && !def.Condition(g.opts) {
+			continue
+		}
+		if err := g.renderTemplate(targetDir, def, data); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (g *Generator) renderTemplate(baseDir string, def templateDefinition, data templateData) error {
+	content, err := templates.FS.ReadFile(def.TemplatePath)
+	if err != nil {
+		return fmt.Errorf("load template %s: %w", def.TemplatePath, err)
+	}
+
+	tmpl, err := template.New(filepath.Base(def.TemplatePath)).Funcs(template.FuncMap{
+		"ToLower": strings.ToLower,
+		"ToUpper": strings.ToUpper,
+	}).Parse(string(content))
+	if err != nil {
+		return fmt.Errorf("parse template %s: %w", def.TemplatePath, err)
+	}
+
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, data); err != nil {
+		return fmt.Errorf("render template %s: %w", def.TemplatePath, err)
+	}
+
+	targetPath := filepath.Join(baseDir, def.TargetPath)
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0o755); err != nil {
+		return fmt.Errorf("create directory for %s: %w", targetPath, err)
+	}
+
+	if err := os.WriteFile(targetPath, buf.Bytes(), 0o644); err != nil {
+		return fmt.Errorf("write file %s: %w", targetPath, err)
+	}
+
+	return nil
+}
+
+type templateData struct {
+	Options
+	ProjectSlug     string
+	ProjectRoot     string
+	HasRoutes       bool
+	HasControllers  bool
+	HasServices     bool
+	HasRepositories bool
+	HasMiddleware   bool
+	HasHelpers      bool
+}
+
+func buildTemplateData(opts Options) templateData {
+	slug := slugify(opts.ProjectName)
+	return templateData{
+		Options:         opts,
+		ProjectSlug:     slug,
+		ProjectRoot:     opts.ProjectName,
+		HasRoutes:       opts.HasModule("routes"),
+		HasControllers:  opts.HasModule("controllers"),
+		HasServices:     opts.HasModule("services"),
+		HasRepositories: opts.HasModule("repositories"),
+		HasMiddleware:   opts.HasModule("middleware"),
+		HasHelpers:      opts.HasModule("helpers"),
+	}
+}
+
+func slugify(name string) string {
+	lower := strings.ToLower(name)
+	sanitized := strings.Builder{}
+	for _, r := range lower {
+		switch {
+		case r >= 'a' && r <= 'z':
+			sanitized.WriteRune(r)
+		case r >= '0' && r <= '9':
+			sanitized.WriteRune(r)
+		default:
+			sanitized.WriteRune('-')
+		}
+	}
+	return strings.Trim(sanitized.String(), "-")
+}
+
+var templateCatalog = []templateDefinition{
+	{TemplatePath: "root/package.json.tmpl", TargetPath: "package.json"},
+	{TemplatePath: "root/README.md.tmpl", TargetPath: "README.md"},
+	{TemplatePath: "root/tsconfig.json.tmpl", TargetPath: "tsconfig.json"},
+	{TemplatePath: "root/eslintrc.cjs.tmpl", TargetPath: ".eslintrc.cjs"},
+	{TemplatePath: "root/prettier.config.cjs.tmpl", TargetPath: "prettier.config.cjs"},
+	{TemplatePath: "root/gitignore.tmpl", TargetPath: ".gitignore"},
+	{TemplatePath: "env/.env.local.tmpl", TargetPath: "config/env/.env.local"},
+	{TemplatePath: "env/.env.dev.tmpl", TargetPath: "config/env/.env.dev"},
+	{TemplatePath: "env/.env.stg.tmpl", TargetPath: "config/env/.env.stg"},
+	{TemplatePath: "env/.env.prod.tmpl", TargetPath: "config/env/.env.prod"},
+	{TemplatePath: "packages/shared/package.json.tmpl", TargetPath: "packages/shared/package.json"},
+	{TemplatePath: "packages/shared/index.ts.tmpl", TargetPath: "packages/shared/index.ts"},
+	{TemplatePath: "packages/shared/database/index.ts.tmpl", TargetPath: "packages/shared/database/index.ts"},
+	{TemplatePath: "packages/shared/cache/redis.ts.tmpl", TargetPath: "packages/shared/cache/redis.ts"},
+	{TemplatePath: "packages/shared/libs/logger.ts.tmpl", TargetPath: "packages/shared/libs/logger.ts"},
+	{TemplatePath: "packages/shared/libs/httpLogger.ts.tmpl", TargetPath: "packages/shared/libs/httpLogger.ts"},
+	{TemplatePath: "packages/shared/helpers/index.ts.tmpl", TargetPath: "packages/shared/helpers/index.ts"},
+	{TemplatePath: "packages/shared/auth/index.ts.tmpl", TargetPath: "packages/shared/auth/index.ts"},
+	{TemplatePath: "packages/shared/auth/jwt.ts.tmpl", TargetPath: "packages/shared/auth/jwt.ts", Condition: func(o Options) bool { return o.Auth == "jwt" }},
+	{TemplatePath: "packages/shared/auth/paseto.ts.tmpl", TargetPath: "packages/shared/auth/paseto.ts", Condition: func(o Options) bool { return o.Auth == "paseto" }},
+	{TemplatePath: "apps/api/package.json.tmpl", TargetPath: "apps/api/package.json", Condition: func(o Options) bool { return o.IncludeAPI }},
+	{TemplatePath: "apps/api/tsconfig.json.tmpl", TargetPath: "apps/api/tsconfig.json", Condition: func(o Options) bool { return o.IncludeAPI }},
+	{TemplatePath: "apps/api/src/app.ts.tmpl", TargetPath: "apps/api/src/app.ts", Condition: func(o Options) bool { return o.IncludeAPI }},
+	{TemplatePath: "apps/api/src/server.ts.tmpl", TargetPath: "apps/api/src/server.ts", Condition: func(o Options) bool { return o.IncludeAPI }},
+	{TemplatePath: "apps/api/src/routes/index.ts.tmpl", TargetPath: "apps/api/src/routes/index.ts", Condition: func(o Options) bool { return o.IncludeAPI && o.HasModule("routes") }},
+	{TemplatePath: "apps/api/src/controllers/index.ts.tmpl", TargetPath: "apps/api/src/controllers/index.ts", Condition: func(o Options) bool { return o.IncludeAPI && o.HasModule("controllers") }},
+	{TemplatePath: "apps/api/src/services/index.ts.tmpl", TargetPath: "apps/api/src/services/index.ts", Condition: func(o Options) bool { return o.IncludeAPI && o.HasModule("services") }},
+	{TemplatePath: "apps/api/src/repositories/index.ts.tmpl", TargetPath: "apps/api/src/repositories/index.ts", Condition: func(o Options) bool { return o.IncludeAPI && o.HasModule("repositories") }},
+	{TemplatePath: "apps/api/src/middleware/index.ts.tmpl", TargetPath: "apps/api/src/middleware/index.ts", Condition: func(o Options) bool { return o.IncludeAPI && o.HasModule("middleware") }},
+	{TemplatePath: "apps/api/src/helpers/index.ts.tmpl", TargetPath: "apps/api/src/helpers/index.ts", Condition: func(o Options) bool { return o.IncludeAPI && o.HasModule("helpers") }},
+	{TemplatePath: "apps/worker/package.json.tmpl", TargetPath: "apps/worker/package.json", Condition: func(o Options) bool { return o.IncludeWorker }},
+	{TemplatePath: "apps/worker/tsconfig.json.tmpl", TargetPath: "apps/worker/tsconfig.json", Condition: func(o Options) bool { return o.IncludeWorker }},
+	{TemplatePath: "apps/worker/src/index.ts.tmpl", TargetPath: "apps/worker/src/index.ts", Condition: func(o Options) bool { return o.IncludeWorker }},
+}

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -1,0 +1,103 @@
+package generator
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGenerateFullProject(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+
+	opts := Options{
+		ProjectName:    "sample-app",
+		OutputDir:      filepath.Join(tmp, "sample-app"),
+		Modules:        []string{"routes", "controllers", "services", "repositories", "middleware", "helpers"},
+		Database:       "mysql",
+		Auth:           "jwt",
+		IncludeAPI:     true,
+		IncludeWorker:  true,
+		CacheNamespace: "core",
+		CacheGroup:     "v1",
+		CacheTTL:       600,
+	}
+
+	if err := New(opts).Generate(context.Background()); err != nil {
+		t.Fatalf("generate project: %v", err)
+	}
+
+	root := opts.OutputDir
+
+	assertFileContains(t, filepath.Join(root, "config/env/.env.local"), "REDIS_NAMESPACE=core")
+	assertFileContains(t, filepath.Join(root, "config/env/.env.local"), "REDIS_TTL=600")
+	assertFileContains(t, filepath.Join(root, "packages/shared/database/index.ts"), "driver: 'mysql'")
+	assertFileContains(t, filepath.Join(root, "packages/shared/package.json"), "\"mysql2\"")
+	assertFileExists(t, filepath.Join(root, "packages/shared/auth/jwt.ts"))
+	assertFileNotExists(t, filepath.Join(root, "packages/shared/auth/paseto.ts"))
+	assertFileExists(t, filepath.Join(root, "apps/api/src/routes/index.ts"))
+	assertFileExists(t, filepath.Join(root, "apps/worker/src/index.ts"))
+}
+
+func TestGenerateWorkerOnlyWithMongoPaseto(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+
+	opts := Options{
+		ProjectName:    "worker-only",
+		OutputDir:      filepath.Join(tmp, "worker-only"),
+		Modules:        []string{},
+		Database:       "mongodb",
+		Auth:           "paseto",
+		IncludeAPI:     false,
+		IncludeWorker:  true,
+		CacheNamespace: "ns",
+		CacheGroup:     "group",
+		CacheTTL:       120,
+	}
+
+	if err := New(opts).Generate(context.Background()); err != nil {
+		t.Fatalf("generate project: %v", err)
+	}
+
+	root := opts.OutputDir
+
+	assertFileContains(t, filepath.Join(root, "packages/shared/database/index.ts"), "MongoClient")
+	assertFileContains(t, filepath.Join(root, "packages/shared/package.json"), "\"mongodb\"")
+	assertFileExists(t, filepath.Join(root, "packages/shared/auth/paseto.ts"))
+	assertFileNotExists(t, filepath.Join(root, "packages/shared/auth/jwt.ts"))
+
+	if _, err := os.Stat(filepath.Join(root, "apps/api")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected API app to be skipped, got err=%v", err)
+	}
+}
+
+func assertFileExists(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected file %s to exist: %v", path, err)
+	}
+}
+
+func assertFileNotExists(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("expected file %s to be absent", path)
+	}
+}
+
+func assertFileContains(t *testing.T, path string, snippet string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read file %s: %v", path, err)
+	}
+	if !strings.Contains(string(data), snippet) {
+		t.Fatalf("expected file %s to contain %q", path, snippet)
+	}
+}

--- a/internal/generator/options.go
+++ b/internal/generator/options.go
@@ -1,0 +1,50 @@
+package generator
+
+// Options captures CLI inputs for project generation.
+type Options struct {
+	ProjectName    string
+	OutputDir      string
+	Modules        []string
+	Database       string
+	Auth           string
+	IncludeAPI     bool
+	IncludeWorker  bool
+	CacheNamespace string
+	CacheGroup     string
+	CacheTTL       int
+}
+
+// HasModule reports whether the requested modules include the provided key.
+func (o Options) HasModule(name string) bool {
+	for _, m := range o.Modules {
+		if m == name {
+			return true
+		}
+	}
+	return false
+}
+
+// Validate ensures the options are consistent.
+func (o Options) Validate() error {
+	switch o.Database {
+	case "mysql", "postgres", "mongodb":
+	default:
+		return ErrUnsupportedDatabase
+	}
+
+	switch o.Auth {
+	case "jwt", "paseto":
+	default:
+		return ErrUnsupportedAuth
+	}
+
+	if o.ProjectName == "" {
+		return ErrMissingProjectName
+	}
+
+	if !o.IncludeAPI && !o.IncludeWorker {
+		return ErrNoAppSelected
+	}
+
+	return nil
+}

--- a/templates/apps/api/package.json.tmpl
+++ b/templates/apps/api/package.json.tmpl
@@ -1,0 +1,20 @@
+{
+  "name": "@{{ .ProjectSlug }}/api",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node dist/server.js",
+    "dev": "ts-node-dev --respawn src/server.ts",
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.0",
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "@types/cors": "^2.8.17",
+    "@types/express": "^4.17.21",
+    "ts-node-dev": "^2.0.0"
+  }
+}

--- a/templates/apps/api/src/app.ts.tmpl
+++ b/templates/apps/api/src/app.ts.tmpl
@@ -1,0 +1,27 @@
+import express from 'express';
+import cors from 'cors';
+import dotenv from 'dotenv';
+
+import { requestLogger } from '../../../packages/shared/libs/httpLogger';
+{{- if .HasMiddleware }}
+import { registerMiddleware } from './middleware';
+{{- end }}
+{{- if .HasRoutes }}
+import { registerRoutes } from './routes';
+{{- end }}
+
+dotenv.config({ path: process.env.ENV_FILE ?? 'config/env/.env.local' });
+
+export function createApp() {
+  const app = express();
+  app.use(cors());
+  app.use(express.json());
+  app.use(requestLogger());
+{{- if .HasMiddleware }}
+  registerMiddleware(app);
+{{- end }}
+{{- if .HasRoutes }}
+  registerRoutes(app);
+{{- end }}
+  return app;
+}

--- a/templates/apps/api/src/controllers/index.ts.tmpl
+++ b/templates/apps/api/src/controllers/index.ts.tmpl
@@ -1,0 +1,13 @@
+import { Request, Response } from 'express';
+{{- if .HasServices }}
+import { exampleService } from '../services';
+{{- end }}
+
+export async function exampleController(_req: Request, res: Response) {
+{{- if .HasServices }}
+  const payload = await exampleService();
+  res.json(payload);
+{{- else }}
+  res.json({ message: 'Example controller' });
+{{- end }}
+}

--- a/templates/apps/api/src/helpers/index.ts.tmpl
+++ b/templates/apps/api/src/helpers/index.ts.tmpl
@@ -1,0 +1,3 @@
+export function buildCacheKey(parts: string[]) {
+  return parts.join(':');
+}

--- a/templates/apps/api/src/middleware/index.ts.tmpl
+++ b/templates/apps/api/src/middleware/index.ts.tmpl
@@ -1,0 +1,15 @@
+import { Express, Request, Response, NextFunction } from 'express';
+import { logger } from '../../../packages/shared/libs/logger';
+
+function requestTimer(req: Request, res: Response, next: NextFunction) {
+  const start = Date.now();
+  res.on('finish', () => {
+    const duration = Date.now() - start;
+    logger.info(`${req.method} ${req.originalUrl} -> ${res.statusCode} (${duration}ms)`);
+  });
+  next();
+}
+
+export function registerMiddleware(app: Express) {
+  app.use(requestTimer);
+}

--- a/templates/apps/api/src/repositories/index.ts.tmpl
+++ b/templates/apps/api/src/repositories/index.ts.tmpl
@@ -1,0 +1,5 @@
+import { healthCheck } from '../../../packages/shared/database';
+
+export async function exampleRepository() {
+  return healthCheck();
+}

--- a/templates/apps/api/src/routes/index.ts.tmpl
+++ b/templates/apps/api/src/routes/index.ts.tmpl
@@ -1,0 +1,17 @@
+import { Express, Router } from 'express';
+{{- if .HasControllers }}
+import { exampleController } from '../controllers';
+{{- end }}
+
+export function registerRoutes(app: Express) {
+  const router = Router();
+
+  router.get('/health', (_req, res) => {
+    res.json({ status: 'ok' });
+  });
+{{- if .HasControllers }}
+  router.get('/example', exampleController);
+{{- end }}
+
+  app.use('/v1', router);
+}

--- a/templates/apps/api/src/server.ts.tmpl
+++ b/templates/apps/api/src/server.ts.tmpl
@@ -1,0 +1,20 @@
+import { createApp } from './app';
+import { logger } from '../../../packages/shared/libs/logger';
+
+type ShutdownHandler = () => void;
+
+const port = Number(process.env.PORT ?? 3000);
+const app = createApp();
+
+const server = app.listen(port, () => {
+  logger.info(`API service listening on port ${port}`);
+});
+
+const shutdownHandlers: ShutdownHandler[] = [
+  () => {
+    server.close(() => logger.info('HTTP server closed'));
+  }
+];
+
+process.on('SIGTERM', () => shutdownHandlers.forEach((handler) => handler()));
+process.on('SIGINT', () => shutdownHandlers.forEach((handler) => handler()));

--- a/templates/apps/api/src/services/index.ts.tmpl
+++ b/templates/apps/api/src/services/index.ts.tmpl
@@ -1,0 +1,11 @@
+{{- if .HasRepositories }}
+import { exampleRepository } from '../repositories';
+{{- end }}
+
+export async function exampleService() {
+{{- if .HasRepositories }}
+  return exampleRepository();
+{{- else }}
+  return { message: 'Example service layer' };
+{{- end }}
+}

--- a/templates/apps/api/tsconfig.json.tmpl
+++ b/templates/apps/api/tsconfig.json.tmpl
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/templates/apps/worker/package.json.tmpl
+++ b/templates/apps/worker/package.json.tmpl
@@ -1,0 +1,17 @@
+{
+  "name": "@{{ .ProjectSlug }}/worker",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "node dist/index.js",
+    "dev": "ts-node-dev --respawn src/index.ts",
+    "build": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "bullmq": "^4.7.0",
+    "dotenv": "^16.4.0"
+  },
+  "devDependencies": {
+    "ts-node-dev": "^2.0.0"
+  }
+}

--- a/templates/apps/worker/src/index.ts.tmpl
+++ b/templates/apps/worker/src/index.ts.tmpl
@@ -1,0 +1,19 @@
+import dotenv from 'dotenv';
+import { Queue, Worker } from 'bullmq';
+
+import { logger } from '../../../packages/shared/libs/logger';
+import { redisClient } from '../../../packages/shared/cache/redis';
+
+dotenv.config({ path: process.env.ENV_FILE ?? 'config/env/.env.local' });
+
+const connection = redisClient();
+
+export function createQueue(name: string) {
+  return new Queue(name, { connection });
+}
+
+export function createWorker(name: string, handler: (payload: unknown) => Promise<void>) {
+  return new Worker(name, async (job) => handler(job.data), { connection });
+}
+
+logger.info('Worker scaffolding ready');

--- a/templates/apps/worker/tsconfig.json.tmpl
+++ b/templates/apps/worker/tsconfig.json.tmpl
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/templates/embed.go
+++ b/templates/embed.go
@@ -1,0 +1,6 @@
+package templates
+
+import "embed"
+
+//go:embed */*.tmpl */*/*.tmpl */*/*/*.tmpl */*/*/*/*.tmpl
+var FS embed.FS

--- a/templates/env/.env.dev.tmpl
+++ b/templates/env/.env.dev.tmpl
@@ -1,0 +1,9 @@
+NODE_ENV=dev
+PORT=3000
+DATABASE_URL=
+REDIS_URL=redis://localhost:6379
+REDIS_NAMESPACE={{ .CacheNamespace }}
+REDIS_GROUP={{ .CacheGroup }}
+REDIS_TTL={{ .CacheTTL }}
+JWT_SECRET=replace-me
+PASETO_SECRET=replace-me

--- a/templates/env/.env.local.tmpl
+++ b/templates/env/.env.local.tmpl
@@ -1,0 +1,9 @@
+NODE_ENV=local
+PORT=3000
+DATABASE_URL=
+REDIS_URL=redis://localhost:6379
+REDIS_NAMESPACE={{ .CacheNamespace }}
+REDIS_GROUP={{ .CacheGroup }}
+REDIS_TTL={{ .CacheTTL }}
+JWT_SECRET=replace-me
+PASETO_SECRET=replace-me

--- a/templates/env/.env.prod.tmpl
+++ b/templates/env/.env.prod.tmpl
@@ -1,0 +1,9 @@
+NODE_ENV=prod
+PORT=3000
+DATABASE_URL=
+REDIS_URL=redis://localhost:6379
+REDIS_NAMESPACE={{ .CacheNamespace }}
+REDIS_GROUP={{ .CacheGroup }}
+REDIS_TTL={{ .CacheTTL }}
+JWT_SECRET=replace-me
+PASETO_SECRET=replace-me

--- a/templates/env/.env.stg.tmpl
+++ b/templates/env/.env.stg.tmpl
@@ -1,0 +1,9 @@
+NODE_ENV=stg
+PORT=3000
+DATABASE_URL=
+REDIS_URL=redis://localhost:6379
+REDIS_NAMESPACE={{ .CacheNamespace }}
+REDIS_GROUP={{ .CacheGroup }}
+REDIS_TTL={{ .CacheTTL }}
+JWT_SECRET=replace-me
+PASETO_SECRET=replace-me

--- a/templates/packages/shared/auth/index.ts.tmpl
+++ b/templates/packages/shared/auth/index.ts.tmpl
@@ -1,0 +1,5 @@
+{{- if eq .Auth "jwt" }}
+export { signJwt as signToken, verifyJwt as verifyToken } from './jwt';
+{{- else }}
+export { signPaseto as signToken, verifyPaseto as verifyToken } from './paseto';
+{{- end }}

--- a/templates/packages/shared/auth/jwt.ts.tmpl
+++ b/templates/packages/shared/auth/jwt.ts.tmpl
@@ -1,0 +1,11 @@
+import jwt from 'jsonwebtoken';
+
+const secret = process.env.JWT_SECRET ?? 'change-me';
+
+export function signJwt<T extends object>(payload: T, expiresIn = '1h') {
+  return jwt.sign(payload, secret, { expiresIn });
+}
+
+export function verifyJwt<T>(token: string) {
+  return jwt.verify(token, secret) as T;
+}

--- a/templates/packages/shared/auth/paseto.ts.tmpl
+++ b/templates/packages/shared/auth/paseto.ts.tmpl
@@ -1,0 +1,11 @@
+import { V4 } from '@panva/paseto';
+
+const secret = (process.env.PASETO_SECRET ?? 'change-me').slice(0, 32).padEnd(32, '0');
+
+export async function signPaseto<T extends object>(payload: T, expiresIn = '1h') {
+  return await new V4().sign(payload, secret, { expiresIn });
+}
+
+export async function verifyPaseto<T>(token: string) {
+  return (await new V4().verify(token, secret)) as T;
+}

--- a/templates/packages/shared/cache/redis.ts.tmpl
+++ b/templates/packages/shared/cache/redis.ts.tmpl
@@ -1,0 +1,39 @@
+import dotenv from 'dotenv';
+import IORedis from 'ioredis';
+
+const namespace = '{{ .CacheNamespace }}';
+const group = '{{ .CacheGroup }}';
+const defaultTTL = {{ .CacheTTL }};
+
+dotenv.config({ path: process.env.ENV_FILE ?? 'config/env/.env.local' });
+
+let client: IORedis | null = null;
+
+export function redisClient() {
+  if (!client) {
+    const redisUrl = process.env.REDIS_URL ?? 'redis://localhost:6379';
+    client = new IORedis(redisUrl);
+  }
+  return client;
+}
+
+export function buildCacheKey(key: string) {
+  return `${namespace}:${group}:${key}`;
+}
+
+export async function setCache(key: string, value: unknown, ttlSeconds = defaultTTL) {
+  const serialized = JSON.stringify(value);
+  const redis = redisClient();
+  await redis.set(buildCacheKey(key), serialized, 'EX', ttlSeconds);
+}
+
+export async function getCache<T>(key: string): Promise<T | null> {
+  const redis = redisClient();
+  const raw = await redis.get(buildCacheKey(key));
+  return raw ? (JSON.parse(raw) as T) : null;
+}
+
+export async function invalidateCache(key: string) {
+  const redis = redisClient();
+  await redis.del(buildCacheKey(key));
+}

--- a/templates/packages/shared/database/index.ts.tmpl
+++ b/templates/packages/shared/database/index.ts.tmpl
@@ -1,0 +1,54 @@
+import dotenv from 'dotenv';
+{{- if ne .Database "mongodb" }}
+import 'reflect-metadata';
+import { DataSource } from 'typeorm';
+{{- else }}
+import { MongoClient } from 'mongodb';
+{{- end }}
+
+dotenv.config({ path: process.env.ENV_FILE ?? 'config/env/.env.local' });
+
+const databaseUrl = process.env.DATABASE_URL ?? '';
+
+if (!databaseUrl) {
+  throw new Error('DATABASE_URL is required to initialize the database client');
+}
+
+{{- if eq .Database "mongodb" }}
+let mongoClient: MongoClient | null = null;
+
+export async function getDatabase() {
+  if (!mongoClient) {
+    mongoClient = new MongoClient(databaseUrl);
+    await mongoClient.connect();
+  }
+  return mongoClient;
+}
+
+export async function healthCheck() {
+  const client = await getDatabase();
+  await client.db().command({ ping: 1 });
+  return { status: 'ok', driver: 'mongodb' };
+}
+{{- else }}
+let dataSource: DataSource | null = null;
+
+export async function getDatabase() {
+  if (!dataSource) {
+    dataSource = new DataSource({
+      type: '{{ .Database }}' as const,
+      url: databaseUrl,
+      synchronize: false,
+      entities: [],
+      migrations: []
+    });
+    await dataSource.initialize();
+  }
+  return dataSource;
+}
+
+export async function healthCheck() {
+  const ds = await getDatabase();
+  return { status: ds.isInitialized ? 'ok' : 'error', driver: '{{ .Database }}' };
+}
+{{- end }}

--- a/templates/packages/shared/helpers/index.ts.tmpl
+++ b/templates/packages/shared/helpers/index.ts.tmpl
@@ -1,0 +1,6 @@
+export function assertDefined<T>(value: T | undefined | null, message: string): T {
+  if (value === undefined || value === null) {
+    throw new Error(message);
+  }
+  return value;
+}

--- a/templates/packages/shared/index.ts.tmpl
+++ b/templates/packages/shared/index.ts.tmpl
@@ -1,0 +1,5 @@
+export * from './database';
+export * from './cache/redis';
+export * from './auth';
+export * from './libs/logger';
+export * from './helpers';

--- a/templates/packages/shared/libs/httpLogger.ts.tmpl
+++ b/templates/packages/shared/libs/httpLogger.ts.tmpl
@@ -1,0 +1,17 @@
+import fs from 'fs';
+import path from 'path';
+import morgan from 'morgan';
+
+const logDirectory = process.env.HTTP_LOG_DIRECTORY ?? 'logs/http';
+
+if (!fs.existsSync(logDirectory)) {
+  fs.mkdirSync(logDirectory, { recursive: true });
+}
+
+const stream = fs.createWriteStream(path.join(logDirectory, `${new Date().toISOString().slice(0, 10)}.log`), {
+  flags: 'a'
+});
+
+export function requestLogger() {
+  return morgan('combined', { stream });
+}

--- a/templates/packages/shared/libs/logger.ts.tmpl
+++ b/templates/packages/shared/libs/logger.ts.tmpl
@@ -1,0 +1,33 @@
+import fs from 'fs';
+import path from 'path';
+import { createLogger, format, transports } from 'winston';
+import DailyRotateFile from 'winston-daily-rotate-file';
+
+type LogLevel = 'info' | 'error' | 'warn';
+
+const logDirectory = process.env.LOG_DIRECTORY ?? 'logs';
+
+if (!fs.existsSync(logDirectory)) {
+  fs.mkdirSync(logDirectory, { recursive: true });
+}
+
+function buildTransport(level: LogLevel) {
+  return new DailyRotateFile({
+    filename: path.join(logDirectory, `${level}-%DATE%.log`),
+    level,
+    datePattern: 'YYYY-MM-DD',
+    zippedArchive: false,
+    maxFiles: '14d'
+  });
+}
+
+export const logger = createLogger({
+  level: 'info',
+  format: format.combine(format.timestamp(), format.json()),
+  transports: [
+    buildTransport('info'),
+    buildTransport('error'),
+    buildTransport('warn'),
+    new transports.Console({ level: process.env.LOG_LEVEL ?? 'info' })
+  ]
+});

--- a/templates/packages/shared/package.json.tmpl
+++ b/templates/packages/shared/package.json.tmpl
@@ -1,0 +1,24 @@
+{
+  "name": "@{{ .ProjectSlug }}/shared",
+  "private": true,
+  "type": "module",
+  "main": "index.ts",
+  "dependencies": {
+{{- if eq .Database "mysql" }}
+    "mysql2": "^3.9.0",
+    "typeorm": "^0.3.19",
+{{- else if eq .Database "postgres" }}
+    "pg": "^8.11.0",
+    "typeorm": "^0.3.19",
+{{- else }}
+    "mongodb": "^6.3.0",
+{{- end }}
+    "dotenv": "^16.4.0",
+    "ioredis": "^5.3.2",
+    "morgan": "^1.10.0",
+    "winston": "^3.11.0",
+    "winston-daily-rotate-file": "^4.7.1"{{- if eq .Auth "jwt" }},
+    "jsonwebtoken": "^9.0.2"{{- else }},
+    "@panva/paseto": "^3.1.0"{{- end }}
+  }
+}

--- a/templates/root/README.md.tmpl
+++ b/templates/root/README.md.tmpl
@@ -1,0 +1,19 @@
+# {{ .ProjectName }}
+
+Generated with `node-creator`.
+
+## Structure
+
+- `apps/api`: HTTP API service.
+- `apps/worker`: Background worker processing jobs.
+- `packages/shared`: Shared libraries (database, cache, auth, logging, helpers).
+- `config/env`: Environment variable presets for local, dev, staging, and production.
+
+## Getting Started
+
+```bash
+npm install
+npm run lint
+```
+
+Each workspace contains its own `package.json` with scripts tailored for the application.

--- a/templates/root/eslintrc.cjs.tmpl
+++ b/templates/root/eslintrc.cjs.tmpl
@@ -1,0 +1,26 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  plugins: ['@typescript-eslint', 'import'],
+  extends: [
+    'eslint:recommended',
+    'plugin:@typescript-eslint/recommended',
+    'plugin:import/recommended',
+    'plugin:import/typescript',
+    'prettier'
+  ],
+  env: {
+    node: true,
+    es2021: true
+  },
+  ignorePatterns: ['dist', 'build', 'node_modules'],
+  rules: {
+    'import/order': [
+      'warn',
+      {
+        alphabetize: { order: 'asc', caseInsensitive: true },
+        newlines-between: 'always'
+      }
+    ]
+  }
+};

--- a/templates/root/gitignore.tmpl
+++ b/templates/root/gitignore.tmpl
@@ -1,0 +1,6 @@
+node_modules
+.env*
+dist
+build
+coverage
+.DS_Store

--- a/templates/root/package.json.tmpl
+++ b/templates/root/package.json.tmpl
@@ -1,0 +1,22 @@
+{
+  "name": "{{ .ProjectName }}",
+  "private": true,
+  "packageManager": "npm@9",
+  "workspaces": [
+    "apps/*",
+    "packages/*"
+  ],
+  "scripts": {
+    "lint": "eslint .",
+    "format": "prettier --write \"**/*.{ts,tsx,js,json}\"",
+    "typecheck": "tsc -b"
+  },
+  "devDependencies": {
+    "eslint": "^8.56.0",
+    "eslint-config-prettier": "^9.1.0",
+    "eslint-plugin-import": "^2.29.0",
+    "eslint-plugin-node": "^11.1.0",
+    "prettier": "^3.2.5",
+    "typescript": "^5.4.0"
+  }
+}

--- a/templates/root/prettier.config.cjs.tmpl
+++ b/templates/root/prettier.config.cjs.tmpl
@@ -1,0 +1,7 @@
+module.exports = {
+  semi: true,
+  singleQuote: true,
+  trailingComma: 'all',
+  printWidth: 100,
+  tabWidth: 2
+};

--- a/templates/root/tsconfig.json.tmpl
+++ b/templates/root/tsconfig.json.tmpl
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "baseUrl": "."
+  },
+  "exclude": ["node_modules", "dist", "build"]
+}


### PR DESCRIPTION
## Summary
- add a Cobra-powered `node-creator` CLI that scaffolds API/worker apps, shared packages, and configurable modules
- provide Node.js template files for monorepo structure, database/redis/auth/logging helpers, and environment presets across local/dev/stg/prod
- cover MySQL/Postgres/MongoDB options, JWT/PASETO auth toggles, and include generator tests plus refreshed documentation

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68e3f0f1857c83288ebb8950a19a2565